### PR TITLE
create helm chart

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -2,3 +2,4 @@ replace-chart-version-with-git: true
 generate-metadata: true
 chart-dir: ./helm/alloy-app
 destination: ./build
+ct-config: ./.circleci/ct-config.yaml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ workflows:
           app_catalog: giantswarm-playground-catalog
           app_catalog_test: giantswarm-playground-test-catalog
           chart: "alloy"
+          ct_config: ".circleci/ct-config.yaml"
           # Trigger job on git tag.
           filters:
             tags:

--- a/.circleci/ct-config.yaml
+++ b/.circleci/ct-config.yaml
@@ -1,0 +1,3 @@
+---
+chart-repos:
+- grafana=https://grafana.github.io/helm-charts

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,7 @@
+checks:
+  exclude:
+  - no-read-only-root-fs
+  - run-as-non-root
+  - non-existent-service-account
+  - unset-cpu-requirements
+  - unset-memory-requirements

--- a/helm/alloy/Chart.yaml
+++ b/helm/alloy/Chart.yaml
@@ -7,7 +7,6 @@ icon: https://s.giantswarm.io/app-icons/grafana-alloy/1/light.png
 sources:
 - https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy
 version: 0.1.0
-annotations:
 maintainers:
   - name: giantswarm/team-atlas
     email: team-atlas@giantswarm.io

--- a/helm/alloy/Chart.yaml
+++ b/helm/alloy/Chart.yaml
@@ -1,22 +1,20 @@
 apiVersion: v2
-appVersion: 0.0.1
-
-# Please make sure your name DOES NOT end in "app" or "-app".
+appVersion: v1.2.0
 name: alloy
-
-# Please describe what the app provides in a sentence or two.
-description: Please add description
-
-home: https://github.com/giantswarm/alloy
-
-# If you have an icon/logo, you should add it to https://github.com/giantswarm/web-assets
-# and set the final URL as a value here and uncomment.
-#icon: https://s.giantswarm.io/app-icons/example/1/light.svg
-
+description: Grafana Alloy OpenTelemetry Collector
+home: https://github.com/giantswarm/alloy-app
+icon: https://s.giantswarm.io/app-icons/grafana-alloy/1/light.png
 sources:
-- https://github.com/some-org/some-repo
-version: 0.0.0-dev # [[ .Version ]] if you're using architect instead of app-build-suite
+- https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy
+version: 0.1.0
 annotations:
-  application.giantswarm.io/team: TEAM-NAME # used through .Chart.Annotations.team (not replaced automatically)
-  branch: my-branch # Used through .Chart.Annotations.branch (This is not replaced automatically)
-  commit: f00bar # Used through .Chart.Annotations.commit (This is not replaced automatically)
+maintainers:
+  - name: giantswarm/team-atlas
+    email: team-atlas@giantswarm.io
+annotations:
+  application.giantswarm.io/team: atlas
+dependencies:
+  - name: alloy
+    version: 0.4.0
+    repository: https://grafana.github.io/helm-charts
+    condition: alloy.enabled

--- a/helm/alloy/Chart.yaml
+++ b/helm/alloy/Chart.yaml
@@ -1,19 +1,19 @@
-apiVersion: v2
-appVersion: v1.2.0
-name: alloy
-description: Grafana Alloy OpenTelemetry Collector
-home: https://github.com/giantswarm/alloy-app
-icon: https://s.giantswarm.io/app-icons/grafana-alloy/1/light.png
-sources:
-- https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy
-version: 0.1.0
-maintainers:
-  - name: giantswarm/team-atlas
-    email: team-atlas@giantswarm.io
 annotations:
   application.giantswarm.io/team: atlas
+apiVersion: v2
+appVersion: v1.2.0
 dependencies:
   - name: alloy
     version: 0.4.0
     repository: https://grafana.github.io/helm-charts
     condition: alloy.enabled
+description: Grafana Alloy OpenTelemetry Collector
+home: https://github.com/giantswarm/alloy-app
+icon: https://s.giantswarm.io/app-icons/grafana-alloy/1/light.png
+maintainers:
+  - name: giantswarm/team-atlas
+    email: team-atlas@giantswarm.io
+name: alloy
+sources:
+- https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy
+version: 0.1.0

--- a/helm/alloy/templates/_helpers.tpl
+++ b/helm/alloy/templates/_helpers.tpl
@@ -1,37 +1,21 @@
-{{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "name" -}}
-{{- .Chart.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-
-{{/*
-Selector labels
-*/}}
-{{- define "labels.selector" -}}
-app.kubernetes.io/name: {{ include "name" . | quote }}
-app.kubernetes.io/instance: {{ .Release.Name | quote }}
-{{- end -}}
-
 {{/*
 Common labels
 */}}
-{{- define "labels.common" -}}
-{{ include "labels.selector" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-application.giantswarm.io/branch: {{ .Chart.Annotations.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
-application.giantswarm.io/commit: {{ .Chart.Annotations.commit | quote }}
-application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+{{- define "alloy.labels" -}}
+helm.sh/chart: {{ include "alloy.chart" . }}
+{{ include "alloy.selectorLabels" . }}
+{{- if index .Values "$chart_tests" }}
+app.kubernetes.io/version: "vX.Y.Z"
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- else }}
+{{/* substr trims delimeter prefix char from alloy.imageId output
+    e.g. ':' for tags and '@' for digests.
+    For digests, we crop the string to a 7-char (short) sha. */}}
+app.kubernetes.io/version: {{ (include "alloy.imageId" .) | trunc 15 | trimPrefix "@sha256" | trimPrefix ":" | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: alloy
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | default "atlas" | quote }}
 giantswarm.io/managed-by: {{ .Release.Name | quote }}
-giantswarm.io/service-type: {{ .Values.serviceType }}
-helm.sh/chart: {{ include "chart" . | quote }}
-{{- end -}}
+giantswarm.io/service-type: managed
+{{- end }}
+{{- end }}

--- a/helm/alloy/values.schema.json
+++ b/helm/alloy/values.schema.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "alloy": {
+            "type": "object",
+            "properties": {
+                "configReloader": {
+                    "type": "object",
+                    "properties": {
+                        "image": {
+                            "type": "object",
+                            "properties": {
+                                "repository": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "repository": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                }
+            }
+        },
+        "global": {
+            "type": "object",
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -1,12 +1,16 @@
-name: alloy
-serviceType: managed
+global:
+  image:
+    registry: gsoci.azurecr.io
 
-project:
-  branch: "[[ .Branch ]]"
-  commit: "[[ .SHA ]]"
+alloy:
+  # You can make the whole chart ineffective by setting enabled to "false"
+  enabled: true
 
-image:
-  registry: quay.io
-  name: giantswarm/alloy
-  tag: v0.0.1
-  pullPolicy: IfNotPresent
+  image:
+    repository: giantswarm/alloy
+  configReloader:
+    image:
+      repository: giantswarm/configmap-reload
+
+  serviceMonitor:
+    enabled: true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3521

Create Alloy helm chart

* use grafana/alloy as dependency
* overwrite docker image with giantswarm images
* overwrite common labels to include giantswarm labels
* enable servicemonitor by default