### PR TITLE
add config examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,9 @@ Anyone with a need to collect observability data and who need an OpenTelemetry c
 
 There are several ways to install this app onto a workload cluster.
 
-- [Using GitOps to instantiate the App](https://docs.giantswarm.io/advanced/gitops/apps/)
-- [Using our web interface](https://docs.giantswarm.io/platform-overview/web-interface/app-platform/#installing-an-app).
-- By creating an [App resource](https://docs.giantswarm.io/use-the-api/management-api/crd/apps.application.giantswarm.io/) in the management cluster as explained in [Getting started with App Platform](https://docs.giantswarm.io/getting-started/app-platform/).
-- Using [kubectl gs](https://docs.giantswarm.io/vintage/use-the-api/kubectl-gs/) command line tool.
+- [Using GitOps](https://docs.giantswarm.io/vintage/advanced/gitops/apps/add_appcr/)
+- [Using our web interface](https://docs.giantswarm.io/vintage/platform-overview/web-interface/app-platform/#installing-an-app)
+- [Using the App platform](https://docs.giantswarm.io/vintage/getting-started/app-platform/deploy-app/) ([kubectl gs template app](https://docs.giantswarm.io/vintage/use-the-api/kubectl-gs/template-app/) reference)
 
 Example with `kubectl gs`:
 

--- a/README.md
+++ b/README.md
@@ -29,14 +29,7 @@ There are several ways to install this app onto a workload cluster.
 
 ## Configuring
 
-### values.yaml
-
-**This is an example of a values file you could upload using our web interface.**
-
-```yaml
-# values.yaml
-
-```
+See examples in [helm/alloy/examples](helm/alloy/examples) for how to configure the app.
 
 ### Sample App CR and ConfigMap for the management cluster
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ There are several ways to install this app onto a workload cluster.
 - [Using GitOps to instantiate the App](https://docs.giantswarm.io/advanced/gitops/apps/)
 - [Using our web interface](https://docs.giantswarm.io/platform-overview/web-interface/app-platform/#installing-an-app).
 - By creating an [App resource](https://docs.giantswarm.io/use-the-api/management-api/crd/apps.application.giantswarm.io/) in the management cluster as explained in [Getting started with App Platform](https://docs.giantswarm.io/getting-started/app-platform/).
+- Using [kubectl gs](https://docs.giantswarm.io/vintage/use-the-api/kubectl-gs/) command line tool.
+
+Example with `kubectl gs`:
+
+```
+kubectl gs template app --name alloy --catalog giantswarm-playground --target-namespace alloy --cluster-name myCluster --version 0.1.0 --user-configmap helm/alloy/examples/mimir-rules/values.yaml | kubectl apply -f -
+```
 
 ## Configuring
 

--- a/helm/alloy/Chart.lock
+++ b/helm/alloy/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: alloy
+  repository: https://grafana.github.io/helm-charts
+  version: 0.4.0
+digest: sha256:765ce19fd71d3df3dc66ccc31ab1f9e075f9d2387dd79d1fade9774e32cf8e59
+generated: "2024-07-01T20:09:38.644743431+02:00"

--- a/helm/alloy/examples/logs/podlogs.yaml
+++ b/helm/alloy/examples/logs/podlogs.yaml
@@ -1,0 +1,10 @@
+apiVersion: monitoring.grafana.com/v1alpha2
+kind: PodLogs
+metadata:
+  name: alloy-podlog
+  labels:
+    foo: bar
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: myApp

--- a/helm/alloy/examples/logs/values.yaml
+++ b/helm/alloy/examples/logs/values.yaml
@@ -1,0 +1,31 @@
+alloy:
+  alloy:
+    configMap:
+      create: true
+      content: |
+        // Select PodLogs with foo=bar label in all namespaces.
+        loki.source.podlogs "default" {
+          forward_to = [loki.process.default.receiver]
+          selector {
+            match_labels = {
+              "foo" = "bar",
+            }
+          }
+        }
+
+        // Filter out log entries that are not valid JSON.
+        loki.process "default" {
+          forward_to = [loki.write.default.receiver]
+
+          stage.json {
+            expressions = {entry = ""}
+            drop_malformed = true
+          }
+        }
+
+        // Send log entries to Loki.
+        loki.write "default" {
+          endpoint {
+            url = "https://loki-gateway.loki/loki/api/v1/push"
+          }
+        }

--- a/helm/alloy/examples/mimir-rules/values.yaml
+++ b/helm/alloy/examples/mimir-rules/values.yaml
@@ -1,0 +1,17 @@
+alloy:
+  alloy:
+    configMap:
+      create: true
+      content: |
+        mimir.rules.kubernetes "local" {
+            // The Mimir Gateway address to import PrometheusRules into.
+            address = "http://mimir-gateway.mimir"
+            tenant_id = "anonymous"
+
+            // Select PrometheusRules with foo=bar label in all namespaces.
+            rule_selector {
+                match_labels = {
+                    "foo" = "bar",
+                }
+            }
+        }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3521

Add Alloy configuration examples for scrapping logs using PodLogs and Loki and importing PrometheusLogs into Mimir.