### PR TITLE
Change catalog from giantswarm-playground to giantswarm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,8 +9,8 @@ workflows:
           context: architect
           executor: app-build-suite
           name: package-and-push-chart
-          app_catalog: giantswarm-playground-catalog
-          app_catalog_test: giantswarm-playground-test-catalog
+          app_catalog: giantswarm-catalog
+          app_catalog_test: giantswarm-test-catalog
           chart: "alloy"
           ct_config: ".circleci/ct-config.yaml"
           # Trigger job on git tag.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change app catalog from giantswarm-playground to giantswarm
+
 ## [0.1.0] - 2024-07-08
 
 - changed: `app.giantswarm.io` label group was changed to `application.giantswarm.io`


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3521

Change App catalog where Alloy is pushed into from giantswarm-playground
to giantswarm.