### PR TITLE
Add Kyverno policy exception for run as non root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add kyverno policy exception for run as non root
+
 ## [0.2.0] - 2024-07-08
 
 ### Changed

--- a/helm/alloy/templates/kyverno-policy-exception.yaml
+++ b/helm/alloy/templates/kyverno-policy-exception.yaml
@@ -19,6 +19,12 @@ spec:
     ruleNames:
     - restricted-volumes
     - autogen-restricted-volumes
+{{- if not .Values.alloy.alloy.securityContext.runAsNonRoot }}
+  - policyName: require-run-as-non-root-user
+    ruleNames:
+    - run-as-non-root-user
+    - autogen-run-as-non-root-user
+{{- end }}
   match:
     any:
     - resources:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3524

This PR adds a Kyverno policy exception to allow Alloy to run as root.
This is required in order to be able to read log files (e.g. /var/log)
from the host machine.