### PR TITLE
add vertical pod autoscaler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add VPA and default resource requests and limits (https://github.com/giantswarm/roadmap/issues/358)
+
 ## [0.4.1] - 2024-08-20
 
 ### Fixed

--- a/helm/alloy/Chart.yaml
+++ b/helm/alloy/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   application.giantswarm.io/team: atlas
 apiVersion: v2
-appVersion: v1.3.0
+appVersion: v1.3.1
 dependencies:
   - name: alloy
     version: 0.7.0

--- a/helm/alloy/templates/vertical-pod-autoscaler.yaml
+++ b/helm/alloy/templates/vertical-pod-autoscaler.yaml
@@ -1,0 +1,42 @@
+### Upstream work being tracked at https://github.com/grafana/alloy/pull/1305
+{{ if .Capabilities.APIVersions.Has "autoscaling.k8s.io/v1" -}}
+{{- if and .Values.verticalPodAutoscaler.enabled -}}
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscaler
+metadata:
+  name: {{ include "alloy.fullname" . }}
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: availability
+spec:
+  {{- with .Values.verticalPodAutoscaler.vertical }}
+  {{- with .recommenders }}
+  recommenders:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .resourcePolicy }}
+  resourcePolicy:
+    {{- with .containerPolicies }}
+    containerPolicies:
+    {{- range . }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- with .updatePolicy }}
+  updatePolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    {{- if eq .Values.alloy.controller.type "deployment" }}
+    kind: Deployment
+    {{- else if eq .Values.alloy.controller.type "statefulset" }}
+    kind: StatefulSet
+    {{- else }}
+    kind: DaemonSet
+    {{- end }}
+    name: {{ include "alloy.fullname" . }}
+{{- end }}
+{{- end }}

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -24,6 +24,17 @@ alloy:
     # Disable reporting to GrafanaLabs
     - --disable-reporting
 
+    extraSecretEnv: []
+
+    # -- Resource requests and limits to apply to the Grafana Alloy container.
+    resources:
+      limits:
+        cpu: "1"
+        memory: 256Mi
+      requests:
+        cpu: 25m
+        memory: 128Mi
+
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
@@ -35,8 +46,6 @@ alloy:
       runAsNonRoot: true
       seccompProfile:
         type: RuntimeDefault
-
-    extraSecretEnv: []
 
   image:
     repository: giantswarm/alloy
@@ -58,3 +67,42 @@ alloy:
 
   serviceMonitor:
     enabled: true
+
+verticalPodAutoscaler:
+  # -- Creates a VerticalPodAutoscaler for the daemonset
+  enabled: false
+
+  # -- List of recommenders to use for the Vertical Pod Autoscaler.
+  # Recommenders are responsible for generating recommendation for the object.
+  # List should be empty (then the default recommender will generate the recommendation)
+  # or contain exactly one recommender.
+  recommenders: []
+  # - name: custom-recommender-performance
+
+  # -- Configures the resource policy for the Vertical Pod Autoscaler.
+  resourcePolicy:
+    # -- Configures the container policies for the Vertical Pod Autoscaler.
+    containerPolicies:
+    - containerName: alloy
+      # -- The controlled resources for the Vertical Pod Autoscaler.
+      controlledResources:
+      - cpu
+      - memory
+      # -- The controlled values for the Vertical Pod Autoscaler. Needs to be either RequestsOnly or RequestsAndLimits.
+      controlledValues: "RequestsAndLimits"
+      # -- The maximum allowed values for the pods.
+      maxAllowed: {}
+      # cpu: 200m
+      # memory: 100Mi
+      # -- Defines the min allowed resources for the pod
+      minAllowed: {}
+      # cpu: 200m
+      # memory: 100Mi
+
+  # -- Configures the update policy for the Vertical Pod Autoscaler.
+  updatePolicy:
+    # -- Specifies minimal number of replicas which need to be alive for VPA Updater to attempt pod eviction
+    # minReplicas: 1
+    # -- Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
+    # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
+    # updateMode: Auto

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -25,14 +25,14 @@ alloy:
     - --disable-reporting
 
     extraSecretEnv: []
-  
+
     mounts:
       # -- Extra volume mounts to add into the Grafana Alloy container.
       extra:
         # This is needed to allow alloy to create files when using readOnlyRootFilesystem
         - name: alloy-tmp
           mountPath: /tmp/alloy
-  
+
     # -- Resource requests and limits to apply to the Grafana Alloy container.
     resources:
       limits:
@@ -100,7 +100,6 @@ verticalPodAutoscaler:
     - containerName: alloy
       # -- The controlled resources for the Vertical Pod Autoscaler.
       controlledResources:
-      - cpu
       - memory
       # -- The controlled values for the Vertical Pod Autoscaler. Needs to be either RequestsOnly or RequestsAndLimits.
       controlledValues: "RequestsAndLimits"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/358

This PR adds a vertical pod autoscaler to alloy and sets some sane defaults resource usage based on the alloy-rules usage:

![image](https://github.com/user-attachments/assets/7b15139e-cf49-4b8f-b18b-270825a96b9f)

### Checklist

- [x] Update changelog in CHANGELOG.md.
