### PR TITLE
push alloy as alloy-gateway to capi MCs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,9 +26,23 @@ workflows:
       - architect/push-to-app-catalog:
           context: architect
           executor: app-build-suite
-          name: package-and-push-chart
+          name: package-and-push-chart-to-giantswarm-catalog
           app_catalog: giantswarm-catalog
           app_catalog_test: giantswarm-test-catalog
+          chart: "alloy"
+          persist_chart_archive: true
+          ct_config: ".circleci/ct-config.yaml"
+          # Trigger job on git tag.
+          filters:
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-catalog:
+          context: architect
+          executor: app-build-suite
+          name: package-and-push-chart-to-control-catalog
+          app_catalog: control-plane-catalog
+          app_catalog_test: control-plane-test-catalog
           chart: "alloy"
           persist_chart_archive: true
           ct_config: ".circleci/ct-config.yaml"
@@ -40,8 +54,64 @@ workflows:
       - architect/run-tests-with-ats:
           name: run-tests-with-ats
           requires:
-            - "package-and-push-chart"
+            - "package-and-push-chart-to-giantswarm-catalog"
           filters:
             branches:
               ignore:
                 - main
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-capa-app-collection
+          app_name: "alloy-gateway"
+          app_namespace: "monitoring"
+          app_collection_repo: "capa-app-collection"
+          requires:
+            - package-and-push-chart-to-control-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-capz-app-collection
+          app_name: "alloy-gateway"
+          app_namespace: "monitoring"
+          app_collection_repo: "capz-app-collection"
+          requires:
+            - package-and-push-chart-to-control-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          context: architect
+          name: push-to-cloud-director-app-collection
+          app_name: "alloy-gateway"
+          app_namespace: "monitoring"
+          app_collection_repo: "cloud-director-app-collection"
+          requires:
+            - package-and-push-chart-to-control-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: vsphere-app-collection
+          context: "architect"
+          app_name: "alloy-gateway"
+          app_namespace: "monitoring"
+          app_collection_repo: "vsphere-app-collection"
+          requires:
+            - package-and-push-chart-to-control-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3568

This PR deploys alloy as an alloy gateway in all CAPI MCs. It needs to be released after [this](https://github.com/giantswarm/shared-configs/pull/151) has been merged 

### Checklist

- [x] Update changelog in CHANGELOG.md.
