### PR TITLE
add PodLogs template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add PodLogs as helm chart template.
+
 ## [0.5.2] - 2024-09-17
 
 ### Added

--- a/helm/alloy/templates/podlogs.yaml
+++ b/helm/alloy/templates/podlogs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ $podLog.name }}
   namespace: {{ $podLog.namespace }}
   labels:
-    {{- include "alloy.labels" . | nindent 4 }}
+    {{- include "alloy.labels" $ | nindent 4 }}
   spec:
 {{- $podLog.spec | toYaml | nindent 4 }}
 {{- end }}

--- a/helm/alloy/templates/podlogs.yaml
+++ b/helm/alloy/templates/podlogs.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: {{ $podLog.namespace }}
   labels:
     {{- include "alloy.labels" $ | nindent 4 }}
-  spec:
-    {{- $podLog.spec | toYaml | nindent 4 }}
+spec:
+  {{- $podLog.spec | toYaml | nindent 2 }}
 {{- end }}

--- a/helm/alloy/templates/podlogs.yaml
+++ b/helm/alloy/templates/podlogs.yaml
@@ -1,4 +1,5 @@
 {{- range $podLog := .Values.podLogs }}
+---
 apiVersion: monitoring.grafana.com/v1alpha2
 kind: PodLogs
 metadata:

--- a/helm/alloy/templates/podlogs.yaml
+++ b/helm/alloy/templates/podlogs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ $podLog.name }}
   namespace: {{ $podLog.namespace }}
   labels:
-    giantswarm.io/managed-by: logging-operator
+    {{- include "alloy.labels" . | nindent 4 }}
   spec:
 {{- $podLog.spec | toYaml | nindent 4 }}
 {{- end }}

--- a/helm/alloy/templates/podlogs.yaml
+++ b/helm/alloy/templates/podlogs.yaml
@@ -1,0 +1,11 @@
+{{- range $podLog := .Values.podLogs }}
+apiVersion: monitoring.grafana.com/v1alpha2
+kind: PodLogs
+metadata:
+  name: {{ $podLog.name }}
+  namespace: {{ $podLog.namespace }}
+  labels:
+    giantswarm.io/managed-by: logging-operator
+  spec:
+{{- $podLog.spec | toYaml | nindent 4 }}
+{{- end }}

--- a/helm/alloy/templates/podlogs.yaml
+++ b/helm/alloy/templates/podlogs.yaml
@@ -8,5 +8,5 @@ metadata:
   labels:
     {{- include "alloy.labels" $ | nindent 4 }}
   spec:
-{{- $podLog.spec | toYaml | nindent 4 }}
+    {{- $podLog.spec | toYaml | nindent 4 }}
 {{- end }}

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -119,3 +119,5 @@ verticalPodAutoscaler:
     # -- Specifies whether recommended updates are applied when a Pod is started and whether recommended updates
     # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
     # updateMode: Auto
+
+podLogs: []

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -120,4 +120,5 @@ verticalPodAutoscaler:
     # are applied during the life of a Pod. Possible values are "Off", "Initial", "Recreate", and "Auto".
     # updateMode: Auto
 
+# Creates PodLogs resources along Alloy
 podLogs: []


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3518

Add PodLogs template to allow passing PodLogs resources via helm chart values. This is required in our setup in order to be able to create PodLogs in the same cluster where Alloy is deployed.