### PR TITLE
add additional config ConfigMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add PodLogs as helm chart template.
+- Add the capability to provide a custom component via a ConfigMap.
 
 ### Changed
 

--- a/helm/alloy/templates/configmap.yaml
+++ b/helm/alloy/templates/configmap.yaml
@@ -1,8 +1,11 @@
 {{- if and .Values.alloy.enabled .Values.additionalConfig.enabled }}
+{{- if not (lookup "v1" "ConfigMap" .Release.Namespace (printf "%s-%s" (include "alloy.fullname" .) "additionalconfig")) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "alloy.fullname" . }}-additionalconfig
+  annotations:
+    helm.sh/resource-policy: keep
   labels:
     {{- include "alloy.labels" . | nindent 4 }}
     app.kubernetes.io/component: config
@@ -23,4 +26,5 @@ data:
       }
     }
     {{- end }}
+{{- end }}
 {{- end }}

--- a/helm/alloy/templates/configmap.yaml
+++ b/helm/alloy/templates/configmap.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.alloy.enabled .Values.additionalConfig.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "alloy.fullname" . }}-additionalconfig
+  labels:
+    {{- include "alloy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+data:
+  config.alloy: |-
+    {{- if .Values.additionalConfig.config }}
+    {{ .Values.additionalConfig.config | nindent 4 }}
+    {{- else }}
+    declare "additional_config" {
+      argument "forward_to" {
+        optional = false
+        comment  = "Where to send collected logs."
+      }
+
+      loki.source.kubernetes "default" {
+        targets    = []
+        forward_to = argument.forward_to.value
+      }
+    }
+    {{- end }}
+{{- end }}

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -122,3 +122,16 @@ verticalPodAutoscaler:
 
 # Creates PodLogs resources along Alloy
 podLogs: []
+
+# Additional configuration for Alloy
+additionalConfig:
+  # -- Enable additional configuration for Alloy
+  # -- This will create a ConfigMap with the additional configuration, it needs to be explicitly mounted using
+  # -- the `alloy.alloy.mounts.extra` and `alloy.controller.volumes.extra` values.
+  enabled: false
+  # -- Additional configuration for Alloy
+  # -- This configure must be a valid Alloy custom component named `additional_config`.
+  # -- https://grafana.com/docs/alloy/latest/reference/config-blocks/declare/
+  # -- It should have a `forward_to` argument used to connect its output to the Alloy pipeline.
+  # -- There is an example of a valid configuration in the configmap template.
+  config: null


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3518

This PR adds the capability to provide an Alloy custom component via a ConfigMap.

This allow for example to extend Alloy configuration using `additionalConfig.config` without modifying the original config provided through `alloy.alloy.configMap`.
The additional custom component can then be imported in the Alloy config and connected to the actual pipeline.
Only caveat is that the additional ConfigMap should be explicitly mounted using values.
Note: the ConfigMap would be created once, and kept as is between upgrade and would not be uninstalled with the chart.

Example:

#### Default config
```rego
// Select PodLogs
loki.source.podlogs "default" {
  forward_to      = [loki.echo.default.receiver]
}

// Import the additional config module
import.file "additional_module" {
  filename = "/etc/alloy-import/"
}

// Instantiate the additional config module
additional_module.additional_config "default" {
  forward_to = [loki.echo.default.receiver]
}

loki.echo "default" {}
```

#### Additional config
```rego
declare "additional_config" {
  argument "forward_to" {
    optional = false
    comment  = "Where to send collected logs."
  }

  discovery.kubernetes "custom" {
    role = "pod"
    selectors {
      role = "pod"
      label = "foo=bar"
    }
  }

  loki.source.kubernetes "custom" {
    targets    = discovery.kubernetes.custom.targets
    forward_to = [loki.process.custom.receiver]
  }

  loki.process "custom" {
    forward_to = argument.forward_to.value
  }
}
```

<details>
<summary>Full values.yaml</summary>

```yaml
alloy:
  alloy:
    configMap:
      create: true
      content: |-
        loki.source.podlogs "default" {
          forward_to      = [loki.echo.default.receiver]
        
          selector {
            match_labels = {
              "giantswarm.io/managed-by" = "alloy-logs",
            }
          }
        
          clustering {
            enabled = true
          }
        }

        import.file "additional_module" {
          filename = "/etc/alloy-import/"
        }

        additional_module.additional_config "default" {
          forward_to = [loki.echo.default.receiver]
        }

        loki.echo "default" {}

        logging {
          level  = "debug"
          format = "logfmt"
        }
    mounts:
      extra:
      - name: alloy-foo-additionalconfig
        mountPath: /etc/alloy-import/
      - name: alloy-tmp
        mountPath: /tmp/alloy
  image:
    tag: v1.4.2
  controller:
    type: deployment
    volumes:
      extra:
      - name: alloy-foo-additionalconfig
        configMap:
          name: alloy-foo-additionalconfig
      - name: alloy-tmp
        emptyDir: {}
additionalConfig:
  enabled: true
  config: |-
    declare "additional_config" {
      argument "forward_to" {
        optional = false
        comment  = "Where to send collected logs."
      }

      discovery.kubernetes "custom" {
        role = "pod"
        selectors {
          role = "pod"
          label = "foo=bar"
        }
      }

      loki.source.kubernetes "custom" {
        targets    = discovery.kubernetes.custom.targets
        forward_to = [loki.process.custom.receiver]
      }

      loki.process "custom" {
        forward_to = argument.forward_to.value
      }
    }
```

</details>

Here is the pipeline graph

![image](https://github.com/user-attachments/assets/d989410b-0bd9-4230-a0b8-4c2511ae2dfb)

The additional module components can be inspected under the `Module components` section

![image](https://github.com/user-attachments/assets/19abfb14-5cda-4cfb-8192-baa004581160)

