### PR TITLE
Fix CiliumNetworkPolicy for clustering mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - See [Alloy v1.4.0 release notes](https://github.com/grafana/alloy/releases/tag/v1.4.0)
   - Helm chart changes, see [Alloy Helm chart v0.9.0 CHANGELOG](https://github.com/grafana/alloy/blob/helm-chart/0.9.0/operations/helm/charts/alloy/CHANGELOG.md)
 
+### Fixed
+
+- Fix CiliumNetworkPolicy to allow outgoing traffic to other nodes when running Alloy in clustering mode
+
 ## [0.5.2] - 2024-09-17
 
 ### Added

--- a/helm/alloy/templates/cilium-networkpolicy.yaml
+++ b/helm/alloy/templates/cilium-networkpolicy.yaml
@@ -37,6 +37,13 @@ spec:
         protocol: ANY
       - port: "443"
         protocol: ANY
+  - toEndpoints:
+    - matchLabels:
+        {{- include "alloy.selectorLabels" . | nindent 8 }}
+    toPorts:
+    - ports:
+      - port: "12345"
+        protocol: TCP
   {{- end }}
   endpointSelector:
     matchLabels:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3518

This PR fixes the CiliumNetworkPolicy to alloy outgoing traffic to other Alloy nodes when running in clustering mode.