### PR TITLE
Reduce CPU limit for alloy container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade Alloy upstream chart from 0.10.0 to 0.10.1
   - This bumps the version of Alloy from 1.5.0 to 1.5.1
+- Reduce CPU limit to 100m for the `alloy` container
 
 ## [0.7.0] - 2024-11-18
 

--- a/helm/alloy/values.yaml
+++ b/helm/alloy/values.yaml
@@ -36,7 +36,7 @@ alloy:
     # -- Resource requests and limits to apply to the Grafana Alloy container.
     resources:
       limits:
-        cpu: "1"
+        cpu: 100m
         memory: 256Mi
       requests:
         cpu: 25m


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32458

This PR reduces the CPU limit for alloy container from 1 CPU to 100m CPU.

This reduces the request to limit ratio from 40 to 4.