### PR TITLE
fix: Remove redundant L7 rule from the CiliumNetworkPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove redundant L7 rule from the CiliumNetworkPolicy. The removed rule allowed DNS queries to any DNS domain so removing it has no effect.
+
 ## [0.20.0] - 2026-06-04
 
 ### Added

--- a/helm/alloy/templates/cilium-networkpolicy.yaml
+++ b/helm/alloy/templates/cilium-networkpolicy.yaml
@@ -25,9 +25,6 @@ spec:
         protocol: ANY
       - port: "1053"
         protocol: ANY
-      rules:
-        dns:
-        - matchPattern: '*'
   - toEndpoints:
     - matchLabels:
         app.kubernetes.io/name: ingress-nginx


### PR DESCRIPTION
Cilium on AKS doesn't have L7 proxy feature enabled, so such policies do not work.

The removed rule allowed DNS queries to any DNS domain so removing it has no effect

Towards: https://github.com/giantswarm/giantswarm/issues/...

### Checklist

- [x] Update changelog in CHANGELOG.md.
