### PR TITLE
fix: ABS config to not override AppVersion in Chart.yaml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
           app_catalog_test: default-test-catalog
           chart: "alloy"
           persist_chart_archive: true
+          override_app_version: false
           ct_config: ".circleci/ct-config.yaml"
           # Trigger job on git tag.
           filters:
@@ -27,10 +28,10 @@ workflows:
           app_catalog_test: default-test-catalog
           chart: "alloy-podlogs-crds"
           persist_chart_archive: true
+          override_app_version: false
           ct_config: ".circleci/ct-config.yaml"
           explicit_allow_chart_name_mismatch: true
           # Trigger job on git tag.
           filters:
             tags:
               only: /^v.*/
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ### Removed
 
 - Remove redundant L7 rule from the CiliumNetworkPolicy. The removed rule allowed DNS queries to any DNS domain so removing it has no effect.


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it. This does not work for this chart, since we use an upstream image with a different version than the chart itself.

### Checklist

- [x] Update changelog in CHANGELOG.md.
